### PR TITLE
Hide radio dots, center symbols, auto-solve on type change

### DIFF
--- a/index.html
+++ b/index.html
@@ -189,15 +189,12 @@
     .radio-option {
       display: flex;
       align-items: center;
-      gap: 0.35rem;
-      padding: 0.4rem 0.7rem;
+      justify-content: center;
+      padding: 0.5rem 0.9rem;
       background: var(--bg-deep);
       border: 1px solid var(--border);
       border-radius: 2px;
       cursor: pointer;
-      font-family: var(--font-mono);
-      font-size: 0.85rem;
-      color: var(--text);
       transition: border-color 0.15s, background 0.15s;
     }
 
@@ -211,8 +208,9 @@
     }
 
     .radio-option input[type="radio"] {
-      accent-color: var(--accent);
-      margin: 0;
+      position: absolute;
+      opacity: 0;
+      pointer-events: none;
     }
 
     .component-symbol {
@@ -1127,10 +1125,14 @@
     }, 20);
   });
 
-  document.querySelectorAll('input').forEach(input => {
+  document.querySelectorAll('input:not([name="type"])').forEach(input => {
     input.addEventListener('keydown', e => {
       if (e.key === 'Enter') solveBtn.click();
     });
+  });
+
+  document.querySelectorAll('input[name="type"]').forEach(radio => {
+    radio.addEventListener('change', () => solveBtn.click());
   });
 
   // Pre-fill an example and solve on page load so visitors see the result immediately


### PR DESCRIPTION
## Summary
- Remove the radio button circle indicator for a cleaner look
- Center circuit symbols within each option
- Automatically re-run simulation when component type changes

## Test plan
- [ ] Verify radio dots are hidden and symbols are centered
- [ ] Switch component type and confirm simulation runs automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)