### PR TITLE
Add standard E12 series fallback when no components specified

### DIFF
--- a/index.html
+++ b/index.html
@@ -485,10 +485,11 @@
       <div class="card-body">
         <div class="form-group">
           <label>Available Components</label>
-          <input type="text" id="components" placeholder="1k, 2.2kx3, 4.7k, 10kx5" />
+          <input type="text" id="components" placeholder="Leave blank for E12 standard, or: 1k, 2.2kx3, 4.7k" />
           <div class="input-help">
             Comma-separated. SI prefixes: <strong>k</strong> (kilo), <strong>M</strong> (mega), <strong>m</strong> (milli), <strong>u</strong> (micro), <strong>n</strong> (nano), <strong>p</strong> (pico).
             Quantity: <strong>4.7kx5</strong> = five 4.7k&#8486;.
+            <strong>Leave blank</strong> to use standard E12 series values.
           </div>
         </div>
 
@@ -1018,6 +1019,42 @@
     return svg;
   }
 
+  // ========== STANDARD COMPONENT VALUES ==========
+  // E12 series: 12 values per decade (10% tolerance standard)
+  const E12_BASE = [1.0, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2];
+
+  function getStandardValues(target, compType) {
+    const values = [];
+    if (compType === 'capacitor') {
+      // Standard capacitor decades: 1pF to 1000µF
+      const decades = [1e-12, 1e-11, 1e-10, 1e-9, 1e-8, 1e-7, 1e-6, 1e-5, 1e-4, 1e-3];
+      for (const dec of decades) {
+        for (const base of E12_BASE) values.push(base * dec);
+      }
+    } else if (compType === 'inductor') {
+      // Standard inductor decades: 1µH to 100mH
+      const decades = [1e-6, 1e-5, 1e-4, 1e-3, 1e-2, 1e-1];
+      for (const dec of decades) {
+        for (const base of E12_BASE) values.push(base * dec);
+      }
+    } else {
+      // Standard resistor decades: 1Ω to 10MΩ
+      const decades = [1, 10, 100, 1e3, 1e4, 1e5, 1e6, 1e7];
+      for (const dec of decades) {
+        for (const base of E12_BASE) values.push(base * dec);
+      }
+    }
+
+    // Filter to values within ~3 decades of target for performance
+    // (solver is combinatorial, so fewer values = faster)
+    if (target > 0) {
+      const lo = target / 1000, hi = target * 1000;
+      const filtered = values.filter(v => v >= lo && v <= hi);
+      if (filtered.length >= 6) return filtered;
+    }
+    return values;
+  }
+
   // ========== UI ==========
   const solveBtn = document.getElementById('solve');
 
@@ -1031,14 +1068,8 @@
     const resultCard = document.getElementById('result');
     const resultBody = document.getElementById('result-body');
 
-    const components = parseComponentList(componentsInput);
     const targetParsed = parseValue(targetInput);
 
-    if (components.length === 0) {
-      resultCard.classList.add('visible');
-      resultBody.innerHTML = '<span class="error-msg">Enter at least one valid component value.</span>';
-      return;
-    }
     if (!targetParsed) {
       resultCard.classList.add('visible');
       resultBody.innerHTML = '<span class="error-msg">Enter a valid target value.</span>';
@@ -1052,6 +1083,10 @@
 
     const target = targetParsed.value;
     const unit = compType === 'capacitor' ? 'F' : compType === 'inductor' ? 'H' : '\u2126';
+
+    const userComponents = parseComponentList(componentsInput);
+    const usingStandard = userComponents.length === 0;
+    const components = usingStandard ? getStandardValues(target, compType) : userComponents;
 
     solveBtn.textContent = '\u25B6 Solving\u2026';
     solveBtn.disabled = true;
@@ -1067,6 +1102,8 @@
         resultBody.innerHTML = '<span class="error-msg">No solution found within the given tolerance. Try increasing tolerance or adding more components.</span>';
         return;
       }
+
+      const stdNote = usingStandard ? '<br><span style="color:var(--text-muted);font-size:0.72rem;">Using standard E12 series values</span>' : '';
 
       const topo = result.topology;
       const errorSign = result.error >= 0 ? '+' : '';
@@ -1085,7 +1122,7 @@
         <div class="result-detail">
           Target: ${formatValue(target, unit)} &middot;
           Error: <strong>${errorSign}${result.error.toFixed(2)}%</strong> &middot;
-          ${result.count} component${result.count > 1 ? 's' : ''}
+          ${result.count} component${result.count > 1 ? 's' : ''}${stdNote}
         </div>
         <div class="result-formula">${formula}</div>
         <div class="circuit-svg">${circuitSvg}</div>
@@ -1106,7 +1143,7 @@
   });
 
   // Pre-fill an example and solve on page load so visitors see the result immediately
-  document.getElementById('components').value = '1k, 2.2kx3, 4.7kx2, 10kx5, 470, 680';
+  document.getElementById('components').value = '';
   document.getElementById('target').value = '9.75k';
   document.getElementById('tolerance').value = '2';
   setTimeout(() => solveBtn.click(), 100);


### PR DESCRIPTION
## Summary
- Users can now solve with just a target value — no need to specify components
- When the components field is left empty, the solver uses standard E12 series values (1.0, 1.2, 1.5, 1.8, 2.2, 2.7, 3.3, 3.9, 4.7, 5.6, 6.8, 8.2) across relevant decades for the selected component type
- Values are filtered to ±3 decades of the target to keep solver performance fast

## Test plan
- [ ] Open page with empty components field — should auto-solve using E12 values and show "Using standard E12 series values" note
- [ ] Enter custom components — should use those instead, no E12 note shown
- [ ] Switch component types (resistor/inductor/capacitor) with empty components — each should use appropriate decade ranges
- [ ] Verify solver performance is acceptable with standard values (no noticeable lag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)